### PR TITLE
IGNITE-24858 Remove search and feedback from docs layout

### DIFF
--- a/_docs/_includes/footer.html
+++ b/_docs/_includes/footer.html
@@ -2,6 +2,6 @@
       {% assign base_url = '' %}
       <nav class="promo-nav">
             <!--#include virtual="/includes/docs_rightnav_promotion.html" -->
-            <a href="#" data-trigger-bugyard-feedback="true" id="doc-feedback-btn">Docs Feedback</a>
+            <!--a href="#" data-trigger-bugyard-feedback="true" id="doc-feedback-btn">Docs Feedback</a-->
         </nav>
         

--- a/_docs/_includes/header.html
+++ b/_docs/_includes/header.html
@@ -60,10 +60,10 @@
         </nav>
 
 
-        <form class='search'>
+        <!--form class='search'>
             <button class="search-close" type='button'><img src='{{"assets/images/cancel.svg"|relative_url}}' alt="close" width="10" height="10" /></button>
             <input type="search" placeholder="Search…" id="search-input">
-        </form>
+        </form-->
         
 
         <nav id="lang-selector"><ul>


### PR DESCRIPTION
As per security policies, search and feedback are currently blocked on docs website. There might be a solution, but it will take time.

Temporarily hide search and feedback for now.