### PR TITLE
[INFRA] Set up default rulesets for default and release branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,8 +1,8 @@
 publish:
   whoami: master
 notifications:
-  commits:      notifications@ignite.apache.org
-  issues:       notifications@ignite.apache.org
+  commits: notifications@ignite.apache.org
+  issues: notifications@ignite.apache.org
   pullrequests: notifications@ignite.apache.org
 github:
   description: "Apache Ignite Website"
@@ -27,10 +27,10 @@ github:
     projects: false
     discussions: false
   enabled_merge_buttons:
-    squash:  true
+    squash: true
     squash_commit_message: PR_TITLE
-    merge:   false
-    rebase:  false
+    merge: false
+    rebase: false
   protected_branches:
     main:
       required_linear_history: true
@@ -38,3 +38,16 @@ github:
       required_conversation_resolution: true
   autolink_jira:
     - IGNITE
+  rulesets:
+    - name: "Default Branch Protection"
+      type: branch
+      branches:
+        includes:
+          - "~DEFAULT_BRANCH"
+          - "release/*"
+          - "rel/*"
+        excludes: []
+      bypass_teams:
+        - root
+      restrict_deletion: true
+      restrict_force_push: true


### PR DESCRIPTION
This Pull Request enables the repository to conform with the "sane default security settings" of the Apache Software Foundation by configuring a default branch ruleset that protects the default branch and any release branches.

Note that `~DEFAULT_BRANCH` is a GitHub symbolic link to the current default branch (HEAD) of the repository and does not need changing.
If the managing project does not wish to set up these defaults, please close this Pull Request. Alternatively, the project may merge this Pull Request to apply the changes immediately.

If no action is taken, this Pull Request will be automatically merged by the Apache Infrastructure team on **2026-06-14** (30 days from now).

For any further information, please reach us on Slack or at: users@infra.apache.org
